### PR TITLE
Improve return type of generate()

### DIFF
--- a/src/rword.ts
+++ b/src/rword.ts
@@ -33,6 +33,8 @@ export class rword {
   /**
    * Randomly generates words from the words array
    */
+  static generate(count: 1, opt?: GenerateOptions): string;
+  static generate(count: number, opt?: GenerateOptions): string[];
   static generate(count: number = 1, opt?: GenerateOptions): string | string[] {
     opt = Object.assign(
       {

--- a/src/rword.ts
+++ b/src/rword.ts
@@ -33,7 +33,7 @@ export class rword {
   /**
    * Randomly generates words from the words array
    */
-  static generate(count: 1, opt?: GenerateOptions): string;
+  static generate(count?: 1, opt?: GenerateOptions): string;
   static generate(count: number, opt?: GenerateOptions): string[];
   static generate(count: number = 1, opt?: GenerateOptions): string | string[] {
     opt = Object.assign(


### PR DESCRIPTION
I ran into an issue when using typescript, where I was unable to chain because the return type was `string | string[]`. I've updated the return type to be `string` when `count: 1`, and `string[]` when it's a different number.